### PR TITLE
fix: compatibility with Android API level 31

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,18 @@ After installing globally the cordova cli, execute:
 cordova plugin add vritra-plugin-notifier
 ```
 
+Example of use:
+```js
+Notifier.notify({
+	title: 'Name of the app',
+	body: 'Some message',
+})
+```
+
+```js
+Notifier.toast({
+	text: 'Some message',
+})
+```
+
 [See documentation](https://vritrajs.github.io/#cordovaplugins#notifier)

--- a/src/android/Action.java
+++ b/src/android/Action.java
@@ -13,6 +13,7 @@ import android.graphics.Bitmap;
 import androidx.core.text.HtmlCompat;
 import android.text.Spanned;
 import android.content.Intent;
+import android.os.Build;
 import android.app.PendingIntent;
 import androidx.core.app.RemoteInput;
 
@@ -58,8 +59,14 @@ public class Action {
         final int notificationId=props.optInt("notificationId");
         intent.putExtra("notificationId",notificationId);
         intent.putExtra("once",props.optBoolean("once"));
-        
-        final PendingIntent pendingIntent=PendingIntent.getBroadcast(Notifier.context,new Random().nextInt(1000),intent,PendingIntent.FLAG_UPDATE_CURRENT);
+
+        final PendingIntent pendingIntent = PendingIntent.getBroadcast(
+            Notifier.context,
+            new Random().nextInt(1000),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT |
+            (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0)
+        );
         
         final Builder builder=new Builder(icon,span!=null?span:label,pendingIntent);
         if(!type.equals("button")){

--- a/src/android/Notification.java
+++ b/src/android/Notification.java
@@ -14,6 +14,7 @@ import androidx.core.app.NotificationManagerCompat;
 import androidx.core.graphics.drawable.IconCompat;
 import androidx.core.text.HtmlCompat;
 import android.content.Intent;
+import android.os.Build;
 import android.app.PendingIntent;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.BitmapDrawable;
@@ -34,7 +35,7 @@ public class Notification {
         this.props=props;
         id=props.optInt("id",new Random().nextInt(1000));
         once=props.optBoolean("once",true);
-        
+
         this.setTitle();
         this.setBody();
         this.setSmallIcon();
@@ -47,7 +48,14 @@ public class Notification {
         final Intent intent=new Intent(Notifier.context,activity.getClass());
         intent.addCategory(Intent.CATEGORY_LAUNCHER);
         intent.setAction(Intent.ACTION_MAIN);
-        final PendingIntent pendingIntent=PendingIntent.getActivity(Notifier.context,id,intent,PendingIntent.FLAG_UPDATE_CURRENT);
+        final PendingIntent pendingIntent = PendingIntent.getActivity(
+            Notifier.context,
+            id,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT |
+            (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0)
+        );
+
         builder.setContentIntent(pendingIntent).setAutoCancel(once);
         try{
             callbacks.put(Integer.toString(id),callbackcontext);


### PR DESCRIPTION
+ add an example of use

Thanks for this great plugin. I fix compatibility with Android API level 31, otherwise this error occurs:

```bash
124 AndroidRuntime E  FATAL EXCEPTION: pool-2-thread-2
Process: com.my.app, PID: 23818
java.lang.IllegalArgumentException: com.my.app: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
	at android.app.PendingIntent.checkPendingIntent(PendingIntent.java:430)
	at android.app.PendingIntent.getActivityAsUser(PendingIntent.java:546)
	at android.app.PendingIntent.getActivity(PendingIntent.java:532)
	at android.app.PendingIntent.getActivity(PendingIntent.java:496)
	at com.vritra.notifier.Notification.<init>(Notification.java:50)
	at com.vritra.notifier.Notifier$1.run(Notifier.java:57)
```